### PR TITLE
Melhorar segurança dos eventos e aguardar as respostas do db

### DIFF
--- a/client/creator.lua
+++ b/client/creator.lua
@@ -57,8 +57,10 @@ local function deleteFarm(args)
         args.farmKey
     )
     if result then
-        lib.callback.await("mri_Qfarm:server:DeleteFarm", false, farm.farmId)
-        args.callback()
+        local result_db = lib.callback.await("mri_Qfarm:server:DeleteFarm", false, farm.farmId)
+        if result_db then
+            args.callback()
+        end
     else
         args.callbackCancel(args.farmKey)
     end
@@ -1305,8 +1307,10 @@ function ListItems(args)
 end
 
 local function saveFarm(args)
-    lib.callback.await("mri_Qfarm:server:SaveFarm", false, Farms[args.farmKey], args.farmKey)
-    args.callback(args.farmKey)
+    local result_db = lib.callback.await("mri_Qfarm:server:SaveFarm", false, Farms[args.farmKey], args.farmKey)
+    if result_db then
+        args.callback(args.farmKey)
+    end
 end
 
 local function actionMenu(key)

--- a/locales/en.json
+++ b/locales/en.json
@@ -165,6 +165,7 @@
     "error.low_durability": "The item cannot be collected because %s's durability is too low.",
     "error.wrong_point_title": "Invalid collection point!",
     "error.wrong_point_message": "Am I in the correct location?",
+    "error.not_authorization": "User does not have the required permission.",
     "progress.pick_farm": "Collecting %s...",
     "progress.craft_progress": "Crafting %s...",
     "task.start_task": "[E] Collect",

--- a/locales/pt-br.json
+++ b/locales/pt-br.json
@@ -165,6 +165,7 @@
     "error.low_durability": "O item não pode ser coletado porque a durabilidade de %s está muito baixa.",
     "error.wrong_point_title": "Ponto de coleta inválido!",
     "error.wrong_point_message": "Estou no local correto?",
+    "error.not_authorization": "Usuário não tem a permissão necessária .",
     "progress.pick_farm": "Coletando %s...",
     "progress.craft_progress": "Fabricação de %s...",
     "task.start_task": "[E] Coletar",

--- a/server/main.lua
+++ b/server/main.lua
@@ -161,6 +161,9 @@ lib.callback.register(
     function(source, farm)
         local source = source
         local response = {type = "success", description = locale("actions.saved")}
+
+        if isPlayerNotAuthorized(source) then return end
+
         if farm.farmId then
             local affectedRows =
                 MySQL.Sync.execute(
@@ -194,6 +197,9 @@ lib.callback.register(
     function(source, farmId)
         local source = source
         local response = {type = "success", description = locale("actions.deleted")}
+
+        if isPlayerNotAuthorized(source) then return end
+
         if not farmId then
             TriggerClientEvent("ox_lib:notify", source, response)
             return
@@ -244,4 +250,21 @@ if GetResourceState("mri_Qbox") ~= "started" then
             lib.callback("mri_Qfarm:manageFarmsMenu", source)
         end
     )
+end
+
+
+
+function isPlayerAuthorized(src)
+    local isAuthorized = false
+    if IsPlayerAceAllowed(src, Config.AuthorizationManager ) then
+        isAuthorized = true;
+    else
+        lib.notify(src, {type = "error", description = locale('error.not_authorization')})
+    end
+
+    return isAuthorized
+end
+
+function isPlayerNotAuthorized(src)
+    return not isPlayerAuthorized(src)
 end

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -1,5 +1,6 @@
 Config = {}
 
+Config.AuthorizationManager = 'admin'
 Config.Debug = false
 Config.UseTarget = true
 Config.ShowMarker = false


### PR DESCRIPTION
ao utilizar callbacks com ox_lib essas callbacks criam eventos que podem ser disparados por usuário mal intencionados. A verificação permite que apenas os usuário com autorização possam deletar ou criar um novo farm.